### PR TITLE
Add api calls to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This function will return the following object:\
 ```
 With the value of `"qrcode"` being a 64bit encoded .png file, which can be displayed directly without any modifications.
 
-To use, you need to make a file happi_keys.krl, which contains the following:
+To use, you need to make a file `happi_keys.krl`, which contains the following:
 ```
 ruleset happi_keys {
     meta {
@@ -26,3 +26,20 @@ ruleset happi_keys {
 ```
 Remember, don't push your api keys :P\
 The .gitignore will ignore any files with *key* in it's name.
+
+## Twilio API
+I modified the twilio API slightly to make it easier to use among our group.\
+Just like the happi API above, you need to make a file called `twilio_keys.krl` which looks like this:
+```
+ruleset twilio_keys {
+    meta {
+        key twilio {
+            "account_sid": "<your twilio account sid>",
+            "auth_token": "<your twilio auth token>",
+            "phone_number_from": "<your twilio phone number>" //remember to include the '+' at the beginning!
+        }
+        provides keys twilio to twilio
+    }
+}
+```
+If you make the file exactly as described, everything should just work.

--- a/qrcode.html
+++ b/qrcode.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page title</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+ 
+    <script>
+            var vars = {};
+            var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
+                vars[key] = value;
+            });
+            console.log("qrcode: ", vars["qrcode"])
+            document.body.innerHTML = '<img src="' + vars["qrcode"] + '">'
+    </script>
+ 
+</body>
+</html>

--- a/twilio.krl
+++ b/twilio.krl
@@ -1,0 +1,20 @@
+ruleset twilio {
+    meta {
+        use module twilio_keys
+        provides send_sms
+        shares send_sms
+    }
+
+    global {
+        send_sms = defaction(message, to, from = keys:twilio{"phone_number_from"}) {
+            account_sid = keys:twilio{"account_sid"}
+            auth_token = keys:twilio{"auth_token"}
+            base_url = <<https://#{account_sid}:#{auth_token}@api.twilio.com/2010-04-01/Accounts/#{account_sid}/>>
+            http:post(base_url + "Messages.json", form = {
+                "From":from,
+                "To":to,
+                "Body":message
+            })
+        }
+    }
+}


### PR DESCRIPTION
As is, the QR code won't be sent to the customers' phone because it's too big to send in an SMS.  The current workaround is this:
When the store:notify_customer event is raised, a link to the QR code (which is also too big to send through SMS) will be returned as a directive.  You can copy/paste that link into a browser to view the QR code.

Other workarounds that I considered:
* send the QRcode (a .png file) through an MMS instead of SMS. Issues:
** MMS messages through Twilio are not free.  a paid account would be needed, and we'd have to hare that api key and auth token.
** Twilio MMS requires that the png file be hosted somewhere, which would require that we have a public server.  This public server would need to have a database of all the png files so it could select and display the appropriate one based on the order id it received.